### PR TITLE
feat: add agent context and API key settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,15 @@ import EventTypeSelector from './components/EventTypeSelector';
 import AgentLibrary from './components/AgentLibrary';
 import EventBuilder from './components/EventBuilder';
 import SimulationView from './components/SimulationView';
+import SettingsModal from './components/SettingsModal';
+import { Settings } from 'lucide-react';
 import { Agent, EventType, Event } from './types';
 
 function App() {
   const [selectedEventType, setSelectedEventType] = useState<EventType | null>(null);
   const [currentEvent, setCurrentEvent] = useState<Event | null>(null);
   const [isSimulating, setIsSimulating] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
 
   const handleEventTypeSelect = (eventType: EventType) => {
     setSelectedEventType(eventType);
@@ -85,14 +88,22 @@ function App() {
                 <p className="text-gray-600 text-xs sm:text-sm hidden sm:block">Design multi-agent interactions and simulations</p>
               </div>
             </div>
-            {currentEvent && (
+            <div className="flex items-center space-x-3">
+              {currentEvent && (
+                <button
+                  onClick={handleResetEvent}
+                  className="px-4 sm:px-6 py-2 sm:py-2.5 bg-white/70 hover:bg-white/90 backdrop-blur-md text-gray-700 rounded-xl transition-all duration-200 border border-gray-200/50 shadow-sm hover:shadow-md transform hover:scale-[1.02] text-sm sm:text-base"
+                >
+                  New Event
+                </button>
+              )}
               <button
-                onClick={handleResetEvent}
-                className="px-4 sm:px-6 py-2 sm:py-2.5 bg-white/70 hover:bg-white/90 backdrop-blur-md text-gray-700 rounded-xl transition-all duration-200 border border-gray-200/50 shadow-sm hover:shadow-md transform hover:scale-[1.02] text-sm sm:text-base"
+                onClick={() => setShowSettings(true)}
+                className="w-10 h-10 sm:w-12 sm:h-12 bg-gray-100/70 hover:bg-gray-200/70 backdrop-blur-sm rounded-xl flex items-center justify-center transition-all duration-200 border border-gray-200/50"
               >
-                New Event
+                <Settings className="w-5 h-5 sm:w-6 sm:h-6 text-gray-700" />
               </button>
-            )}
+            </div>
           </div>
         </div>
       </header>
@@ -102,8 +113,8 @@ function App() {
         {!selectedEventType ? (
           <EventTypeSelector onSelect={handleEventTypeSelect} />
         ) : isSimulating ? (
-          <SimulationView 
-            event={currentEvent!} 
+          <SimulationView
+            event={currentEvent!}
             onBack={() => setIsSimulating(false)}
           />
         ) : (
@@ -122,6 +133,7 @@ function App() {
           </div>
         )}
       </main>
+      {showSettings && <SettingsModal onClose={() => setShowSettings(false)} />}
     </div>
   );
 }

--- a/src/components/AgentConfigModal.tsx
+++ b/src/components/AgentConfigModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { X, Settings } from 'lucide-react';
+import { X } from 'lucide-react';
 import { Agent } from '../types';
 
 interface AgentConfigModalProps {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useEffect } from 'react';
+import { X, Key } from 'lucide-react';
+import { getApiKey, saveApiKey } from '../utils/apiKey';
+
+interface SettingsModalProps {
+  onClose: () => void;
+}
+
+export default function SettingsModal({ onClose }: SettingsModalProps) {
+  const [apiKey, setApiKey] = useState('');
+
+  useEffect(() => {
+    setApiKey(getApiKey());
+  }, []);
+
+  const handleSave = () => {
+    saveApiKey(apiKey);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="backdrop-blur-xl bg-white/90 rounded-3xl w-full max-w-md shadow-xl border border-gray-200/50">
+        <div className="flex items-center justify-between p-6 border-b border-gray-200/50">
+          <div className="flex items-center space-x-3">
+            <Key className="w-6 h-6 text-gray-700" />
+            <h2 className="text-xl font-semibold text-gray-900">API Settings</h2>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-10 h-10 bg-gray-100/70 hover:bg-gray-200/70 backdrop-blur-sm rounded-xl flex items-center justify-center transition-all duration-200 border border-gray-200/50"
+          >
+            <X className="w-5 h-5 text-gray-700" />
+          </button>
+        </div>
+        <div className="p-6 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-900 mb-2">API Key</label>
+            <input
+              type="password"
+              value={apiKey}
+              onChange={e => setApiKey(e.target.value)}
+              placeholder="Enter your API key"
+              className="w-full bg-white/80 backdrop-blur-sm border border-gray-200/50 rounded-xl px-4 py-3 text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-transparent"
+            />
+          </div>
+          <button
+            onClick={handleSave}
+            className="w-full px-4 py-2.5 bg-blue-500 hover:bg-blue-600 text-white rounded-xl font-medium transition-colors duration-200"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SimulationView.tsx
+++ b/src/components/SimulationView.tsx
@@ -11,7 +11,7 @@ interface DebatePhase {
   name: string;
   description: string;
   timeLimit: number;
-  icon: React.ComponentType<any>;
+  icon: React.ComponentType<unknown>;
 }
 
 const debatePhases: DebatePhase[] = [
@@ -68,6 +68,7 @@ export default function SimulationView({ event, onBack }: SimulationViewProps) {
   const [simulationSteps, setSimulationSteps] = useState<SimulationStep[]>([]);
   const [activeAgent, setActiveAgent] = useState<Agent | null>(null);
   const [agentScores, setAgentScores] = useState<{[key: string]: number}>({});
+  const [agentContexts, setAgentContexts] = useState<Record<string, string[]>>({});
 
   // Initialize agent scores
   useEffect(() => {
@@ -78,6 +79,15 @@ export default function SimulationView({ event, onBack }: SimulationViewProps) {
     setAgentScores(initialScores);
   }, [event.agents]);
 
+  // Initialize agent contexts
+  useEffect(() => {
+    const initialContexts: Record<string, string[]> = {};
+    event.agents.forEach(agent => {
+      initialContexts[agent.id] = [];
+    });
+    setAgentContexts(initialContexts);
+  }, [event.agents]);
+
   // Debate simulation logic
   useEffect(() => {
     if (!isRunning) return;
@@ -86,18 +96,32 @@ export default function SimulationView({ event, onBack }: SimulationViewProps) {
       const randomAgent = event.agents[Math.floor(Math.random() * event.agents.length)];
       const currentPhaseName = debatePhases[currentPhase]?.name || 'Opening Statements';
       const phaseMessages = debateMessages[currentPhaseName as keyof typeof debateMessages] || debateMessages['Opening Statements'];
-      const message = phaseMessages[Math.floor(Math.random() * phaseMessages.length)];
+      const contextForAgent = agentContexts[randomAgent.id] || [];
+      const contextPrefix = contextForAgent.length > 0 ? `In response to "${contextForAgent[contextForAgent.length - 1]}", ` : '';
+      const message = contextPrefix + phaseMessages[Math.floor(Math.random() * phaseMessages.length)];
 
       const newStep: SimulationStep = {
         agentId: randomAgent.id,
-        message: message,
+        message,
         timestamp: new Date(),
         round: currentPhase + 1,
-        phase: currentPhaseName
+        phase: currentPhaseName,
+        context: contextForAgent
       };
 
       setSimulationSteps(prev => [...prev, newStep]);
       setActiveAgent(randomAgent);
+
+      setAgentContexts(prev => {
+        const updated = { ...prev };
+        event.agents.forEach(agent => {
+          if (agent.id !== randomAgent.id) {
+            const history = updated[agent.id] || [];
+            updated[agent.id] = [...history, `${randomAgent.name}: ${message}`].slice(-5);
+          }
+        });
+        return updated;
+      });
 
       // Update scores based on performance
       setAgentScores(prev => ({
@@ -116,7 +140,7 @@ export default function SimulationView({ event, onBack }: SimulationViewProps) {
     }, 3000);
 
     return () => clearInterval(interval);
-  }, [isRunning, event.agents, currentPhase, phaseTimer]);
+  }, [isRunning, event.agents, currentPhase, phaseTimer, agentContexts]);
 
   const getAgentById = (id: string) => event.agents.find(agent => agent.id === id);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,4 +35,5 @@ export interface SimulationStep {
   timestamp: Date;
   round: number;
   phase?: string;
+  context?: string[];
 }

--- a/src/utils/apiKey.ts
+++ b/src/utils/apiKey.ts
@@ -1,0 +1,7 @@
+export const getApiKey = (): string => {
+  return localStorage.getItem('apiKey') || import.meta.env.VITE_OPENAI_API_KEY || '';
+};
+
+export const saveApiKey = (key: string): void => {
+  localStorage.setItem('apiKey', key);
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_OPENAI_API_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- track per-agent message context during simulations
- allow users to configure an API key via settings modal
- declare Vite env variable for default API key

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8c66bc924832bbc5d6bb1766cc92f